### PR TITLE
Add workflow to run multiple WGSFromBam in parallel

### DIFF
--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WGSFromBam.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WGSFromBam.wdl
@@ -114,8 +114,8 @@ workflow WGSFromBam {
     File? gvcf_summary_metrics = WGSFromFastq.gvcf_summary_metrics
     File? gvcf_detail_metrics = WGSFromFastq.gvcf_detail_metrics
 
-    File? output_bam = WGSFromFastq.provided_output_bam
-    File? output_bam_index = WGSFromFastq.provided_output_bam_index
+    File? output_bam = WGSFromFastq.output_bam
+    File? output_bam_index = WGSFromFastq.output_bam_index
 
     File? output_cram = WGSFromFastq.output_cram
     File? output_cram_index = WGSFromFastq.output_cram_index

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WGSFromFastq.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WGSFromFastq.wdl
@@ -147,7 +147,7 @@ workflow WGSFromFastq {
       haplotype_scatter_count = scatter_settings.haplotype_scatter_count,
       break_bands_at_multiples_of = scatter_settings.break_bands_at_multiples_of,
       input_bam = mapped_bam,
-      input_bai = mapped_index,
+      input_bam_index = mapped_index,
       ref_fasta = references.reference_fasta.ref_fasta,
       ref_fasta_index = references.reference_fasta.ref_fasta_index,
       ref_dict = references.reference_fasta.ref_dict,

--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WGSMultipleSamplesFromBam.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WGSMultipleSamplesFromBam.wdl
@@ -1,0 +1,66 @@
+version 1.0
+
+import "WGSFromBam.wdl" as WGSFromBam
+
+
+workflow WGSMultipleSamplesFromBam {
+
+  String pipeline_version = "1.0.0"
+
+  input {
+    File sample_map
+
+    DNASeqSingleSampleReferences references
+    VariantCallingScatterSettings scatter_settings
+    PapiSettings papi_settings
+    Boolean to_cram = false
+    Boolean check_contamination = true
+    Boolean check_fingerprints = false
+    Boolean do_bqsr = false
+
+    File? fingerprint_genotypes_file
+    File? fingerprint_genotypes_index
+
+    File wgs_coverage_interval_list
+
+    Boolean provide_bam_output = false
+    Boolean use_gatk3_haplotype_caller = true
+    Boolean validate_gvcf = true
+  }
+
+  Array[Array[String]] sample_map_lines = read_tsv(sample_map)
+  Int num_samples = length(sample_map_lines)  
+
+  scatter (idx in range(num_samples)) {
+    String sample_name = sample_map_lines[idx][0]
+    File input_bam = sample_map_lines[idx][1]
+    
+    call WGSFromBam.WGSFromBam as WGSFromBam {
+      input:
+        input_bam = input_bam,
+        sample_name = sample_name,
+        base_file_name = sample_name,
+        final_gvcf_base_name = sample_name,
+        references = references,
+        scatter_settings = scatter_settings,
+        fingerprint_genotypes_file = fingerprint_genotypes_file,
+        fingerprint_genotypes_index = fingerprint_genotypes_index,
+        papi_settings = papi_settings,
+        wgs_coverage_interval_list = wgs_coverage_interval_list,
+  
+        to_cram = to_cram,
+        check_contamination = check_contamination,
+        check_fingerprints = check_fingerprints,
+        validate_gvcf = validate_gvcf,
+        provide_bam_output = provide_bam_output
+    }
+  }
+
+  output {
+    Array[File] output_vcfs = select_all(WGSFromBam.output_vcf)
+    Array[File] output_vcf_idx = select_all(WGSFromBam.output_vcf_index)
+  }
+  meta {
+    allowNestedInputs: true
+  }
+}

--- a/tasks/broad/FastqsToAlignedBam.wdl
+++ b/tasks/broad/FastqsToAlignedBam.wdl
@@ -166,6 +166,7 @@ workflow FastqsToAlignedBam {
       call Processing.BaseRecalibrator as BaseRecalibrator {
         input:
           input_bam = SortSampleBam.output_bam,
+          input_bam_index = SortSampleBam.output_bam_index,
           recalibration_report_filename = sample_and_fastqs.base_file_name + ".recal_data.csv",
           sequence_group_interval = subgroup,
           dbsnp_vcf = select_first([references.dbsnp_vcf]),
@@ -194,6 +195,7 @@ workflow FastqsToAlignedBam {
       call Processing.ApplyBQSR as ApplyBQSR {
         input:
           input_bam = SortSampleBam.output_bam,
+          input_bam_index = SortSampleBam.output_bam_index,
           output_bam_basename = recalibrated_bam_basename,
           recalibration_report = GatherBqsrReports.output_bqsr_report,
           sequence_group_interval = subgroup,


### PR DESCRIPTION
Add a workflow to run WGSFromBam.wdl (a BAM to gVCF workflow - our modified version of the Broad's one) on multiple samples in parallel.

Going to also push the code into https://github.com/populationgenomics/cpg-fewgenomes that generates the input for this workflow.

(Also, adds a tiny fix WGSFromBam.wdl itself).