### PR TITLE
Compress fastq files

### DIFF
--- a/pipelines/broad/dna_seq/germline/single_sample/wgs/WGSFromBam.wdl
+++ b/pipelines/broad/dna_seq/germline/single_sample/wgs/WGSFromBam.wdl
@@ -53,7 +53,7 @@ workflow WGSFromBam {
     input:
       input_bam = SortSamByName.output_bam,
       output_fq_basename = base_file_name,
-      disk_size = ceil(input_size * 6) + 20
+      disk_size = ceil(size(SortSamByName.output_bam, "GiB") * 6) + 20
   }
 
   SampleAndFastqs sample_and_fastqs = object {
@@ -143,9 +143,11 @@ task BamToFastq {
   String ref_arg = if defined(ref_fasta) then "--reference ~{ref_fasta}" else ""
   command <<<
     samtools fastq ~{input_bam} \
-    ~{ref_arg} \
     -1 ~{output_fq_basename}.1.fq \
     -2 ~{output_fq_basename}.2.fq \
+    ~{ref_arg} \
+    -1 ~{output_fq_basename}_R1.fastq.gz \
+    -2 ~{output_fq_basename}_R2.fastq.gz \
     -0 /dev/null -s /dev/null
   >>>
 
@@ -157,7 +159,7 @@ task BamToFastq {
   }
 
   output {
-    File output_fq1 = output_fq_basename + '.1.fq'
-    File output_fq2 = output_fq_basename + '.2.fq'
+    File output_fq1 = "~{output_fq_basename}_R1.fastq.gz"
+    File output_fq2 = "~{output_fq_basename}_R2.fastq.gz"
   }
 }

--- a/tasks/broad/FastqsToAlignedBam.wdl
+++ b/tasks/broad/FastqsToAlignedBam.wdl
@@ -59,7 +59,7 @@ workflow FastqsToAlignedBam {
   # Get the size of the standard reference files as well as the additional reference files needed for BWA
 
   scatter (fastq_pair in sample_and_fastqs.fastqs) {
-    String input_basename = basename(fastq_pair[0], '_1.fastq.gz')
+    String input_basename = basename(fastq_pair[0], '_R1.fastq.gz')
     Float fastq_size = size(fastq_pair[0], "GiB") + size(fastq_pair[1], "GiB")
 
     call Alignment.SamToFastqAndBwaMemAndMba as SamToFastqAndBwaMemAndMba {


### PR DESCRIPTION
Also take sorted BAM size into account, instead of the original input BAM. Those sizes can be quite different, e.g.
CRAM (37 GB) --> BAM (70 GB) --> sorted BAM (117 GB) --> fastq (2 * 174 GB).